### PR TITLE
Update runtime to 50

### DIFF
--- a/io.github.diegopvlk.Dosage.json
+++ b/io.github.diegopvlk.Dosage.json
@@ -1,5 +1,5 @@
 {
-	"app-id": "io.github.diegopvlk.Dosage",
+	"id": "io.github.diegopvlk.Dosage",
 	"runtime": "org.gnome.Platform",
 	"runtime-version": "50",
 	"sdk": "org.gnome.Sdk",

--- a/io.github.diegopvlk.Dosage.json
+++ b/io.github.diegopvlk.Dosage.json
@@ -39,8 +39,8 @@
 				{
 					"type": "git",
 					"url": "https://github.com/diegopvlk/Dosage",
-					"tag": "v2.1.4",
-					"commit": "eef60a1aca456da206f9d6a62de1e69450c69b82"
+					"tag": "v2.1.5",
+					"commit": "b40faa5002ff2a84c21f02e420316ea8926ea76a"
 				}
 			]
 		}

--- a/io.github.diegopvlk.Dosage.json
+++ b/io.github.diegopvlk.Dosage.json
@@ -15,13 +15,7 @@
 	"cleanup": [
 		"/include",
 		"/lib/pkgconfig",
-		"/man",
-		"/share/doc",
-		"/share/gtk-doc",
-		"/share/man",
-		"/share/pkgconfig",
-		"*.la",
-		"*.a"
+		"/share/gir-1.0"
 	],
 	"modules": [
 		{

--- a/io.github.diegopvlk.Dosage.json
+++ b/io.github.diegopvlk.Dosage.json
@@ -1,7 +1,7 @@
 {
 	"app-id": "io.github.diegopvlk.Dosage",
 	"runtime": "org.gnome.Platform",
-	"runtime-version": "49",
+	"runtime-version": "50",
 	"sdk": "org.gnome.Sdk",
 	"command": "io.github.diegopvlk.Dosage",
 	"finish-args": [


### PR DESCRIPTION
- Update the runtime version to 50
- Improve cleanup commands to reduce the Flatpak size
- Drop ineffective cleanup commands